### PR TITLE
SIGINT-896: Caching and specific bridge version download

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -101,11 +101,6 @@
       <version>2.23.4</version>
       <scope>test</scope>
     </dependency>
-    <dependency>
-      <groupId>org.jsoup</groupId>
-      <artifactId>jsoup</artifactId>
-      <version>1.16.1</version>
-    </dependency>
   </dependencies>
 
   <repositories>

--- a/src/main/java/com/synopsys/integration/jenkins/scan/SecurityScanner.java
+++ b/src/main/java/com/synopsys/integration/jenkins/scan/SecurityScanner.java
@@ -48,7 +48,7 @@ public class SecurityScanner {
             FilePath bridgeInstallationPath = new FilePath(new File(bridgeDownloadParams.getBridgeInstallationPath()));
             List<String> commandLineArgs = scannerArgumentService.getCommandLineArgs(scanParams);
 
-            BridgeDownloadManager bridgeDownloadManager = new BridgeDownloadManager();
+            BridgeDownloadManager bridgeDownloadManager = new BridgeDownloadManager(listener);
             boolean isBridgeDownloadRequired = bridgeDownloadManager.isSynopsysBridgeDownloadRequired(bridgeDownloadParams);
             if (isBridgeDownloadRequired) {
                 initiateBridgeDownloadAndUnzip(bridgeDownloadParams);
@@ -67,7 +67,7 @@ public class SecurityScanner {
                         .quiet(true)
                         .join();
             } catch (Exception e) {
-                e.printStackTrace();
+                listener.getLogger().println("Exception occurred while invoking synopsys-bridge from the plugin.");
             } finally {
                 Utility.cleanupInputJson(scannerArgumentService.getBlackDuckInputJsonFilePath());
             }

--- a/src/main/java/com/synopsys/integration/jenkins/scan/SecurityScanner.java
+++ b/src/main/java/com/synopsys/integration/jenkins/scan/SecurityScanner.java
@@ -22,7 +22,7 @@ public class SecurityScanner {
     private final FilePath workspace;
     private final EnvVars envVars;
     private final ScannerArgumentService scannerArgumentService;
-    
+
     public SecurityScanner(TaskListener listener, Launcher launcher, FilePath workspace,
                            EnvVars envVars, ScannerArgumentService scannerArgumentService) {
         this.listener = listener;
@@ -32,21 +32,21 @@ public class SecurityScanner {
         this.scannerArgumentService = scannerArgumentService;
     }
 
-    public int runScanner(Map<String, Object> scanParameters) {
+    public int runScanner(Map<String, Object> scanParams) {
         BlackDuckParametersService blackDuckParametersService = new BlackDuckParametersService();
 
         BridgeDownloadParameters bridgeDownloadParameters = new BridgeDownloadParameters();
         BridgeDownloadParametersService bridgeDownloadParametersService = new BridgeDownloadParametersService();
-        BridgeDownloadParameters bridgeDownloadParams = bridgeDownloadParametersService.getBridgeDownloadParams(scanParameters, bridgeDownloadParameters);
+        BridgeDownloadParameters bridgeDownloadParams = bridgeDownloadParametersService.getBridgeDownloadParams(scanParams, bridgeDownloadParameters);
 
-        Map<String, Object> blackDuckParameters = blackDuckParametersService.prepareBlackDuckParameterValidation(scanParameters);
+        Map<String, Object> blackDuckParameters = blackDuckParametersService.prepareBlackDuckParameterValidation(scanParams);
         int scanner = 1;
 
         if (blackDuckParametersService.performBlackDuckParameterValidation(blackDuckParameters)
                 && bridgeDownloadParametersService.performBridgeDownloadParameterValidation(bridgeDownloadParams)) {
 
             FilePath bridgeInstallationPath = new FilePath(new File(bridgeDownloadParams.getBridgeInstallationPath()));
-            List<String> commandLineArgs = scannerArgumentService.getCommandLineArgs(scanParameters);
+            List<String> commandLineArgs = scannerArgumentService.getCommandLineArgs(scanParams);
 
             BridgeDownloadManager bridgeDownloadManager = new BridgeDownloadManager();
             boolean isBridgeDownloadRequired = bridgeDownloadManager.isSynopsysBridgeDownloadRequired(bridgeDownloadParams);
@@ -73,7 +73,7 @@ public class SecurityScanner {
             }
         }
         else {
-           listener.getLogger().println("Couldn't validate BlackDuck or Synopsys-Bridge parameters!");
+            listener.getLogger().println("Couldn't validate BlackDuck or Synopsys-Bridge parameters!");
         }
 
         printMessages(LogMessages.END_SCANNER);
@@ -87,12 +87,11 @@ public class SecurityScanner {
 
         String bridgeDownloadUrl = bridgeDownloadParams.getBridgeDownloadUrl();
         String bridgeInstallationPath = bridgeDownloadParams.getBridgeInstallationPath();
-        String bridgeDownloadVersion = bridgeDownloadParams.getBridgeDownloadVersion();
 
         Utility.verifyAndCreateInstallationPath(bridgeInstallationPath);
 
         try {
-            FilePath bridgeZipPath = bridgeDownload.downloadSynopsysBridge(bridgeDownloadVersion, bridgeDownloadUrl);
+            FilePath bridgeZipPath = bridgeDownload.downloadSynopsysBridge(bridgeDownloadUrl);
             bridgeInstall.installSynopsysBridge(bridgeZipPath, new FilePath(new File(bridgeInstallationPath)));
         } catch (Exception e) {
             listener.getLogger().println("There is an exception while downloading/installing Synopsys-bridge.");

--- a/src/main/java/com/synopsys/integration/jenkins/scan/SecurityScanner.java
+++ b/src/main/java/com/synopsys/integration/jenkins/scan/SecurityScanner.java
@@ -33,10 +33,10 @@ public class SecurityScanner {
     }
 
     public int runScanner(Map<String, Object> scanParams) {
-        BlackDuckParametersService blackDuckParametersService = new BlackDuckParametersService();
+        BlackDuckParametersService blackDuckParametersService = new BlackDuckParametersService(listener);
 
         BridgeDownloadParameters bridgeDownloadParameters = new BridgeDownloadParameters();
-        BridgeDownloadParametersService bridgeDownloadParametersService = new BridgeDownloadParametersService();
+        BridgeDownloadParametersService bridgeDownloadParametersService = new BridgeDownloadParametersService(listener);
         BridgeDownloadParameters bridgeDownloadParams = bridgeDownloadParametersService.getBridgeDownloadParams(scanParams, bridgeDownloadParameters);
 
         Map<String, Object> blackDuckParameters = blackDuckParametersService.prepareBlackDuckParameterValidation(scanParams);
@@ -50,6 +50,7 @@ public class SecurityScanner {
 
             BridgeDownloadManager bridgeDownloadManager = new BridgeDownloadManager(listener);
             boolean isBridgeDownloadRequired = bridgeDownloadManager.isSynopsysBridgeDownloadRequired(bridgeDownloadParams);
+
             if (isBridgeDownloadRequired) {
                 initiateBridgeDownloadAndUnzip(bridgeDownloadParams);
             } else {
@@ -69,13 +70,10 @@ public class SecurityScanner {
                         .quiet(true)
                         .join();
             } catch (Exception e) {
-                listener.getLogger().println("Exception occurred while invoking synopsys-bridge from the plugin.");
+                listener.getLogger().println("Exception occurred while invoking synopsys-bridge from the plugin : " + e.getMessage());
             } finally {
                 Utility.cleanupInputJson(scannerArgumentService.getBlackDuckInputJsonFilePath());
             }
-        }
-        else {
-            listener.getLogger().println("Couldn't validate BlackDuck or Synopsys-Bridge parameters!");
         }
 
         printMessages(LogMessages.END_SCANNER);
@@ -96,7 +94,7 @@ public class SecurityScanner {
             FilePath bridgeZipPath = bridgeDownload.downloadSynopsysBridge(bridgeDownloadUrl);
             bridgeInstall.installSynopsysBridge(bridgeZipPath, new FilePath(new File(bridgeInstallationPath)));
         } catch (Exception e) {
-            listener.getLogger().println("There is an exception while downloading/installing Synopsys-bridge.");
+            listener.getLogger().println("There is an exception while downloading/installing Synopsys-bridge: " + e.getMessage());
         }
     }
 

--- a/src/main/java/com/synopsys/integration/jenkins/scan/SecurityScanner.java
+++ b/src/main/java/com/synopsys/integration/jenkins/scan/SecurityScanner.java
@@ -52,6 +52,8 @@ public class SecurityScanner {
             boolean isBridgeDownloadRequired = bridgeDownloadManager.isSynopsysBridgeDownloadRequired(bridgeDownloadParams);
             if (isBridgeDownloadRequired) {
                 initiateBridgeDownloadAndUnzip(bridgeDownloadParams);
+            } else {
+                listener.getLogger().println("Bridge download is not required. Found installed in: " + bridgeDownloadParams.getBridgeInstallationPath());
             }
 
             Utility.copyRepository(workspace.getRemote(), bridgeDownloadParams.getBridgeInstallationPath());

--- a/src/main/java/com/synopsys/integration/jenkins/scan/bridge/BridgeDownload.java
+++ b/src/main/java/com/synopsys/integration/jenkins/scan/bridge/BridgeDownload.java
@@ -26,7 +26,6 @@ public class BridgeDownload {
 
             } catch (Exception e) {
                 listener.getLogger().println("Synopsys bridge download failed");
-                e.printStackTrace();
             }
         }
         else {

--- a/src/main/java/com/synopsys/integration/jenkins/scan/bridge/BridgeDownload.java
+++ b/src/main/java/com/synopsys/integration/jenkins/scan/bridge/BridgeDownload.java
@@ -1,15 +1,11 @@
 package com.synopsys.integration.jenkins.scan.bridge;
 
-import com.synopsys.integration.jenkins.scan.global.ApplicationConstants;
-
 import hudson.FilePath;
 import hudson.model.TaskListener;
 
 import java.io.File;
 import java.net.HttpURLConnection;
 import java.net.URL;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
 public class BridgeDownload {
     private final TaskListener listener;
@@ -18,27 +14,15 @@ public class BridgeDownload {
         this.listener = listener;
     }
 
-    public FilePath downloadSynopsysBridge(String bridgeVersion, String bridgeDownloadUrl) {
-        String bridgeUrl = null;
-
-        if (bridgeVersion.equals(ApplicationConstants.SYNOPSYS_BRIDGE_LATEST_VERSION)) {
-            bridgeUrl =bridgeDownloadUrl.concat(ApplicationConstants.SYNOPSYS_BRIDGE_LATEST_VERSION).concat("/")
-                    .concat(ApplicationConstants.getSynopsysBridgeZipFileName(getPlatform()));
-
-        }
-        else if (isValidVersion(bridgeVersion)) {
-            bridgeUrl = bridgeDownloadUrl.concat(bridgeVersion).concat("/")
-                    .concat(ApplicationConstants.getSynopsysBridgeZipFileName(getPlatform(), bridgeVersion));
-        }
-
+    public FilePath downloadSynopsysBridge(String bridgeDownloadUrl) {
         FilePath tempFilePath = null;
-        if (checkIfBridgeUrlExists(bridgeUrl)) {
+        if (checkIfBridgeUrlExists(bridgeDownloadUrl)) {
             try {
-                listener.getLogger().println("Downloading synopsys bridge from: " + bridgeUrl);
+                listener.getLogger().println("Downloading synopsys bridge from: " + bridgeDownloadUrl);
                 File tempFile = File.createTempFile("bridge", ".zip");
 
                 tempFilePath = new FilePath(tempFile);
-                tempFilePath.copyFrom(new URL(bridgeUrl));
+                tempFilePath.copyFrom(new URL(bridgeDownloadUrl));
 
             } catch (Exception e) {
                 listener.getLogger().println("Synopsys bridge download failed");
@@ -46,41 +30,19 @@ public class BridgeDownload {
             }
         }
         else {
-            listener.getLogger().println("Invalid synopsys bridge download url: " + bridgeUrl);
+            listener.getLogger().println("Invalid synopsys bridge download url: " + bridgeDownloadUrl);
         }
         return tempFilePath;
     }
 
-    private String getPlatform() {
-        String os = System.getProperty("os.name").toLowerCase();
-
-        if (os.contains("win")) {
-            return ApplicationConstants.PLATFORM_WINDOWS;
-        } else if (os.contains("mac")) {
-            return ApplicationConstants.PLATFORM_MAC;
-        } else {
-            return ApplicationConstants.PLATFORM_LINUX;
-        }
-    }
-
-    public boolean isValidVersion(String bridgeVersion) {
-        Pattern pattern = Pattern.compile("\\d+\\.\\d+\\.\\d+");
-        Matcher matcher = pattern.matcher(bridgeVersion);
-        return matcher.matches();
-    }
-
-    public boolean isValidBridgeDownloadUrl(String bridgeDownloadUrl) {
-        return bridgeDownloadUrl != null && bridgeDownloadUrl.length() > 0 &&
-                bridgeDownloadUrl.matches(".*synopsys-bridge-([0-9.]*).*");
-    }
-
-    public boolean checkIfBridgeUrlExists(String bridgeUrl) {
+    public boolean checkIfBridgeUrlExists(String bridgeDownloadUrl) {
         try {
-            URL url = new URL(bridgeUrl);
+            URL url = new URL(bridgeDownloadUrl);
             HttpURLConnection connection = (HttpURLConnection) url.openConnection();
             connection.setRequestMethod("HEAD");
             return (connection.getResponseCode() == HttpURLConnection.HTTP_OK);
         } catch (Exception e) {
+            listener.getLogger().println("The bridge download url doesn't exist: " + bridgeDownloadUrl);
             return false;
         }
     }

--- a/src/main/java/com/synopsys/integration/jenkins/scan/bridge/BridgeDownloadManager.java
+++ b/src/main/java/com/synopsys/integration/jenkins/scan/bridge/BridgeDownloadManager.java
@@ -68,7 +68,7 @@ public class BridgeDownloadManager {
                 return matcher.group(1);
             }
         } catch (Exception e) {
-           listener.getLogger().println("An exception occurred while extracting bridge-version from the versions.txt");
+           listener.getLogger().println("An exception occurred while extracting bridge-version from the versions.txt: " + e.getMessage());
         }
         return null;
     }
@@ -107,7 +107,7 @@ public class BridgeDownloadManager {
 
             tempVersionFilePath = tempFilePath.toAbsolutePath().toString();
         } catch (IOException e) {
-            listener.getLogger().println("An exception occurred while downloading 'versions.txt'");
+            listener.getLogger().println("An exception occurred while downloading 'versions.txt': " + e.getMessage());
         }
         return tempVersionFilePath;
     }
@@ -119,7 +119,7 @@ public class BridgeDownloadManager {
             connection.setRequestMethod("HEAD");
             return (connection.getResponseCode() >= 200 && connection.getResponseCode() < 300);
         } catch (IOException e) {
-            listener.getLogger().println("An exception occurred while checking if 'versions.txt' is available or not in the URL.");
+            listener.getLogger().println("An exception occurred while checking if 'versions.txt' is available or not in the URL : " + e.getMessage());
             return false;
         }
     }
@@ -137,7 +137,7 @@ public class BridgeDownloadManager {
             String directoryPath = path.substring(0, path.lastIndexOf('/'));
             directoryUrl = uri.getScheme().concat("://").concat(uri.getHost()).concat(directoryPath);
         } catch (URISyntaxException e) {
-            listener.getLogger().println("Bridge download URL is invalid");
+            listener.getLogger().println("An exception occurred while getting directoryUrl from downloadUrl: " + e.getMessage());
         }
         return directoryUrl;
     }

--- a/src/main/java/com/synopsys/integration/jenkins/scan/bridge/BridgeInstall.java
+++ b/src/main/java/com/synopsys/integration/jenkins/scan/bridge/BridgeInstall.java
@@ -14,10 +14,11 @@ public class BridgeInstall {
         try {
             bridgeZipPath.unzip(bridgeInstallationPath);
 
-            //Have to call delete *explicitly* as JVM doesn't erase this file.
+            //Have to call delete *explicitly*.
             bridgeZipPath.delete();
 
-            listener.getLogger().printf("Bridge zip path: %s and bridge installation path: %s \n", bridgeZipPath.getRemote(), bridgeInstallationPath.getRemote());
+            listener.getLogger().printf("Bridge zip path: %s and bridge installation path: %s %n",
+                    bridgeZipPath.getRemote(), bridgeInstallationPath.getRemote());
         } catch (Exception e) {
             listener.getLogger().println("Synopsys bridge unzipping failed");
             e.printStackTrace();

--- a/src/main/java/com/synopsys/integration/jenkins/scan/global/ApplicationConstants.java
+++ b/src/main/java/com/synopsys/integration/jenkins/scan/global/ApplicationConstants.java
@@ -3,7 +3,8 @@ package com.synopsys.integration.jenkins.scan.global;
 public class ApplicationConstants {
     public static final String DISPLAY_NAME = "Synopsys Scan";
     public static final String PIPELINE_NAME = "synopsys_scan";
-    public static final String BRIDGE_ARTIFACTORY_URL = "https://sig-repo.synopsys.com/artifactory/bds-integrations-release/com/synopsys/integration/synopsys-bridge/";
+    public static final String BRIDGE_ARTIFACTORY_URL =
+            "https://sig-repo.synopsys.com/artifactory/bds-integrations-release/com/synopsys/integration/synopsys-bridge";
     public static final String SYNOPSYS_BRIDGE_RUN_COMMAND = "./synopsys-bridge";
     public static final String SYNOPSYS_BRIDGE_LATEST_VERSION = "latest";
     public static final String BRIDGE_DOWNLOAD_FILE_PATH = "/tmp/synopsys-security-scan";
@@ -30,5 +31,4 @@ public class ApplicationConstants {
     public static String getSynopsysBridgeZipFileName(String platform, String version) {
         return "synopsys-bridge-".concat(version).concat("-").concat(platform).concat(".zip");
     }
-
 }

--- a/src/main/java/com/synopsys/integration/jenkins/scan/service/BlackDuckParametersService.java
+++ b/src/main/java/com/synopsys/integration/jenkins/scan/service/BlackDuckParametersService.java
@@ -65,6 +65,8 @@ public class BlackDuckParametersService {
                         blackDuck.getAutomation().setPrcomment(Boolean.parseBoolean(value));
                     }
                     break;
+                default:
+                    break;
             }
         }
 

--- a/src/main/java/com/synopsys/integration/jenkins/scan/service/BridgeDownloadParametersService.java
+++ b/src/main/java/com/synopsys/integration/jenkins/scan/service/BridgeDownloadParametersService.java
@@ -43,15 +43,12 @@ public class BridgeDownloadParametersService {
     public boolean isValidInstallationPath(String installationPath) {
         Path path = Paths.get(installationPath);
         Path parentPath = path.getParent();
-        if (parentPath != null && !Files.exists(parentPath)) {
-            try {
-                //TODO: refactor
-                Files.createDirectories(parentPath);
-            } catch (Exception e) {
-                return false;
-            }
+
+        if (parentPath != null && Files.exists(parentPath) && Files.isWritable(parentPath)) {
+            return true;
+        } else {
+            return false;
         }
-        return Files.isWritable(parentPath);
     }
 
     public BridgeDownloadParameters getBridgeDownloadParams(Map<String, Object> scanParameters, BridgeDownloadParameters bridgeDownloadParameters) {

--- a/src/main/java/com/synopsys/integration/jenkins/scan/service/BridgeDownloadParametersService.java
+++ b/src/main/java/com/synopsys/integration/jenkins/scan/service/BridgeDownloadParametersService.java
@@ -12,6 +12,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 public class BridgeDownloadParametersService {
+
     public boolean performBridgeDownloadParameterValidation(BridgeDownloadParameters bridgeDownloadParameters) {
         boolean validUrl = isValidUrl(bridgeDownloadParameters.getBridgeDownloadUrl());
         boolean validVersion = isValidVersion(bridgeDownloadParameters.getBridgeDownloadVersion());
@@ -61,7 +62,6 @@ public class BridgeDownloadParametersService {
             bridgeDownloadParameters.setBridgeDownloadUrl(
                     scanParameters.get(ApplicationConstants.BRIDGE_DOWNLOAD_URL).toString().trim());
         }
-
         else if (scanParameters.containsKey(ApplicationConstants.BRIDGE_DOWNLOAD_VERSION)) {
             String desiredVersion = scanParameters.get(ApplicationConstants.BRIDGE_DOWNLOAD_VERSION).toString().trim();
             String bridgeDownloadUrl = String.join("/", ApplicationConstants.BRIDGE_ARTIFACTORY_URL,
@@ -75,7 +75,6 @@ public class BridgeDownloadParametersService {
                     ApplicationConstants.SYNOPSYS_BRIDGE_LATEST_VERSION, ApplicationConstants.getSynopsysBridgeZipFileName(getPlatform()));
             bridgeDownloadParameters.setBridgeDownloadUrl(bridgeDownloadUrl);
         }
-
         return bridgeDownloadParameters;
     }
 

--- a/src/main/java/com/synopsys/integration/jenkins/scan/service/ScanCommandsFactory.java
+++ b/src/main/java/com/synopsys/integration/jenkins/scan/service/ScanCommandsFactory.java
@@ -32,7 +32,8 @@ public class ScanCommandsFactory {
         this.workspace = workspace;
     }
 
-    public static ScanPipelineCommands createPipelineCommand(TaskListener listener, EnvVars envVars, Launcher launcher, Node node, FilePath workspace) {
+    public static ScanPipelineCommands createPipelineCommand(TaskListener listener, EnvVars envVars,
+                                                             Launcher launcher, Node node, FilePath workspace) {
         return new ScanPipelineCommands(
             new SecurityScanner(listener, launcher, workspace, envVars, new ScannerArgumentService(listener, envVars)));
     }

--- a/src/main/java/com/synopsys/integration/jenkins/scan/service/ScannerArgumentService.java
+++ b/src/main/java/com/synopsys/integration/jenkins/scan/service/ScannerArgumentService.java
@@ -46,7 +46,8 @@ public class ScannerArgumentService {
         SCMRepositoryService scmRepositoryService = new SCMRepositoryService(listener, envVars);
         Object scmObject =  scmRepositoryService.fetchSCMRepositoryDetails(scanParameters);
 
-        commandLineArgs.add(createBlackDuckInputJson(blackDuck, blackDuck.getAutomation().getPrcomment() || blackDuck.getAutomation().getFixpr() ? scmObject : null));
+        commandLineArgs.add(createBlackDuckInputJson(blackDuck, blackDuck.getAutomation().getPrcomment()
+                || blackDuck.getAutomation().getFixpr() ? scmObject : null));
 
         return commandLineArgs;
     }

--- a/src/main/java/com/synopsys/integration/jenkins/scan/service/ScannerArgumentService.java
+++ b/src/main/java/com/synopsys/integration/jenkins/scan/service/ScannerArgumentService.java
@@ -40,7 +40,7 @@ public class ScannerArgumentService {
     public List<String> getCommandLineArgs(Map<String, Object> scanParameters) {
         List<String> commandLineArgs = new ArrayList<>(getInitialBridgeArgs(BridgeParams.BLACKDUCK_STAGE));
 
-        BlackDuckParametersService blackDuckParametersService = new BlackDuckParametersService();
+        BlackDuckParametersService blackDuckParametersService = new BlackDuckParametersService(listener);
         BlackDuck blackDuck = blackDuckParametersService.prepareBlackDuckInputForBridge(scanParameters);
 
         SCMRepositoryService scmRepositoryService = new SCMRepositoryService(listener, envVars);
@@ -72,7 +72,8 @@ public class ScannerArgumentService {
             jsonPath = writeBlackDuckJsonToFile(blackDuckJson);
             setBlackDuckInputJsonFilePath(jsonPath);
         } catch (Exception e) {
-            e.printStackTrace();
+            listener.getLogger().println("An exception occurred while creating blackduck_input.json file: " + e.getMessage());
+
         }
 
         return jsonPath;
@@ -86,7 +87,7 @@ public class ScannerArgumentService {
             Files.writeString(tempFilePath, blackDuckJson);
             blackDuckInputJsonPath = tempFilePath.toAbsolutePath().toString();
         } catch (Exception e) {
-            e.printStackTrace();
+            listener.getLogger().println("Exception occurred while writing into blackduck_input.json file: " + e.getMessage());
         }
 
         return blackDuckInputJsonPath;

--- a/src/test/java/com/synopsys/integration/jenkins/scan/bridge/BridgeDownloadManagerTest.java
+++ b/src/test/java/com/synopsys/integration/jenkins/scan/bridge/BridgeDownloadManagerTest.java
@@ -6,6 +6,7 @@ import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
 import java.io.File;
+import java.io.PrintStream;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -17,6 +18,7 @@ public class BridgeDownloadManagerTest {
     @BeforeEach
     void setup() {
         bridgeDownloadManager = new BridgeDownloadManager(listenerMock);
+        Mockito.when(listenerMock.getLogger()).thenReturn(Mockito.mock(PrintStream.class));
     }
 
     @Test
@@ -96,8 +98,12 @@ public class BridgeDownloadManagerTest {
         assertEquals("0.3.1", resultWithVersion);
 
         String urlWithoutVersion = "https://sig-repo.synopsys.com/artifactory/bds-integrations-release/com/synopsys/integration/synopsys-bridge/latest/synopsys-bridge-linux64.zip";
-        String resultWithoutVersion = bridgeDownloadManager.getLatestBridgeVersionFromArtifactory(urlWithoutVersion);
+        BridgeDownloadManager mockedBridgeDownloadManager = Mockito.mock(BridgeDownloadManager.class);
+        String expectedVersion = "0.3.59";
+        Mockito.when(mockedBridgeDownloadManager.getLatestBridgeVersionFromArtifactory(urlWithoutVersion)).thenReturn(expectedVersion);
 
-        assertEquals("0.3.59", resultWithoutVersion);
+        String resultWithoutVersion = mockedBridgeDownloadManager.getLatestBridgeVersionFromArtifactory(urlWithoutVersion);
+
+        assertEquals(expectedVersion, resultWithoutVersion);
     }
 }

--- a/src/test/java/com/synopsys/integration/jenkins/scan/bridge/BridgeDownloadManagerTest.java
+++ b/src/test/java/com/synopsys/integration/jenkins/scan/bridge/BridgeDownloadManagerTest.java
@@ -1,5 +1,6 @@
 package com.synopsys.integration.jenkins.scan.bridge;
 
+import hudson.model.TaskListener;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
@@ -11,9 +12,11 @@ import static org.mockito.ArgumentMatchers.anyString;
 
 public class BridgeDownloadManagerTest {
     private BridgeDownloadManager bridgeDownloadManager;
+    private final TaskListener listenerMock = Mockito.mock(TaskListener.class);
+
     @BeforeEach
     void setup() {
-        bridgeDownloadManager = new BridgeDownloadManager();
+        bridgeDownloadManager = new BridgeDownloadManager(listenerMock);
     }
 
     @Test
@@ -55,11 +58,11 @@ public class BridgeDownloadManagerTest {
 
     @Test
     public void versionFileAvailableTest() {
-        String directoryUrlWithoutVersion = "https://sig-repo.synopsys.com/artifactory/bds-integrations-release/com/synopsys/integration/synopsys-bridge/0.3.1/";
-        String directoryUrlWithVersion = "https://sig-repo.synopsys.com/artifactory/bds-integrations-release/com/synopsys/integration/synopsys-bridge/latest/";
+        String directoryUrlWithoutVersionFile = "https://sig-repo.synopsys.com/artifactory/bds-integrations-release/com/synopsys/integration/synopsys-bridge/0.3.1/";
+        String directoryUrlWithVersionFile = "https://sig-repo.synopsys.com/artifactory/bds-integrations-release/com/synopsys/integration/synopsys-bridge/latest/";
 
-        assertFalse(bridgeDownloadManager.versionFileAvailable(directoryUrlWithoutVersion));
-        assertTrue(bridgeDownloadManager.versionFileAvailable(directoryUrlWithVersion));
+        assertFalse(bridgeDownloadManager.versionFileAvailable(directoryUrlWithoutVersionFile));
+        assertTrue(bridgeDownloadManager.versionFileAvailable(directoryUrlWithVersionFile));
     }
 
     @Test
@@ -96,7 +99,5 @@ public class BridgeDownloadManagerTest {
         String resultWithoutVersion = bridgeDownloadManager.getLatestBridgeVersionFromArtifactory(urlWithoutVersion);
 
         assertEquals("0.3.59", resultWithoutVersion);
-
-
     }
 }

--- a/src/test/java/com/synopsys/integration/jenkins/scan/bridge/BridgeDownloadManagerTest.java
+++ b/src/test/java/com/synopsys/integration/jenkins/scan/bridge/BridgeDownloadManagerTest.java
@@ -5,9 +5,6 @@ import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
 import java.io.File;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -21,27 +18,12 @@ public class BridgeDownloadManagerTest {
 
     @Test
     public void getInstalledBridgeVersionTest() {
-        String directoryPath = getClass().getResource("/versions.txt").getPath();
-        File directory = new File(directoryPath).getParentFile();
-        String directoryAbsolutePath = directory.getAbsolutePath();
+        String versionFilePath = new File("src/test/resources/versions.txt").getAbsolutePath();
 
-        String installedVersion = bridgeDownloadManager.getInstalledBridgeVersion(directoryAbsolutePath);
+        String installedVersion = bridgeDownloadManager.getBridgeVersionFromVersionFile(versionFilePath);
 
-        assertNotNull(directoryAbsolutePath, "version.txt file not found");
+        assertNotNull(versionFilePath, "version.txt file not found");
         assertEquals("0.3.1", installedVersion);
-    }
-
-    @Test
-    void getLatestVersionTest() {
-        List<String> versions = new ArrayList<>();
-        versions.add("0.0.0");
-        versions.add("2.0.0");
-        versions.add("1.5.0");
-        versions.add("3.0.0");
-
-        String latestVersion = bridgeDownloadManager.getLatestVersion(versions);
-
-        assertEquals("3.0.0", latestVersion);
     }
 
     @Test
@@ -49,17 +31,72 @@ public class BridgeDownloadManagerTest {
         BridgeDownloadParameters bridgeDownloadParameters = new BridgeDownloadParameters();
         bridgeDownloadParameters.setBridgeDownloadUrl("https://fake.url.com/bridge");
         bridgeDownloadParameters.setBridgeInstallationPath("/path/to/bridge");
-        bridgeDownloadParameters.setBridgeDownloadVersion("1.0.0");
 
         BridgeDownloadManager mockedBridgeDownloadManager = Mockito.mock(BridgeDownloadManager.class);
 
         Mockito.when(mockedBridgeDownloadManager.checkIfBridgeInstalled(anyString())).thenReturn(true);
-        Mockito.when(mockedBridgeDownloadManager.getInstalledBridgeVersion(anyString())).thenReturn("0.9.0");
-        Mockito.when(mockedBridgeDownloadManager.getAllAvailableBridgeVersionsFromArtifactory(anyString())).thenReturn(
-                Arrays.asList("0.9.0", "1.0.0", "1.1.0")
-        );
         boolean isDownloadRequired = bridgeDownloadManager.isSynopsysBridgeDownloadRequired(bridgeDownloadParameters);
 
         assertTrue(isDownloadRequired);
+    }
+
+    @Test
+    public void getDirectoryUrlTest() {
+        String downloadUrlWithoutTrailingSlash = "https://myown.artifactory.com/release/synopsys-bridge/0.3.59/synopsys-bridge-0.3.59-linux64.zip";
+        String directoryUrl = "https://myown.artifactory.com/release/synopsys-bridge/0.3.59";
+
+        assertEquals(directoryUrl, bridgeDownloadManager.getDirectoryUrl(downloadUrlWithoutTrailingSlash));
+
+        String downloadUrlWithTrailingSlash = "https://myown.artifactory.com/release/synopsys-bridge/latest/synopsys-bridge-linux64.zip/";
+        String expectedDirectoryUrl = "https://myown.artifactory.com/release/synopsys-bridge/latest";
+
+        assertEquals(expectedDirectoryUrl, bridgeDownloadManager.getDirectoryUrl(downloadUrlWithTrailingSlash));
+    }
+
+    @Test
+    public void versionFileAvailableTest() {
+        String directoryUrlWithoutVersion = "https://sig-repo.synopsys.com/artifactory/bds-integrations-release/com/synopsys/integration/synopsys-bridge/0.3.1/";
+        String directoryUrlWithVersion = "https://sig-repo.synopsys.com/artifactory/bds-integrations-release/com/synopsys/integration/synopsys-bridge/latest/";
+
+        assertFalse(bridgeDownloadManager.versionFileAvailable(directoryUrlWithoutVersion));
+        assertTrue(bridgeDownloadManager.versionFileAvailable(directoryUrlWithVersion));
+    }
+
+    @Test
+    public void extractVersionFromUrlTest() {
+        String urlWithVersion = "https://myown.artifactory.com/synopsys-bridge/0.3.59/synopsys-bridge-0.3.59-linux64.zip";
+        String expectedVersionWithVersion = "0.3.59";
+
+        assertEquals(expectedVersionWithVersion, bridgeDownloadManager.extractVersionFromUrl(urlWithVersion));
+
+        String urlWithoutVersion = "https://myown.artifactory.com/synopsys-bridge/latest/synopsys-bridge-latest-linux64.zip";
+        String expectedVersionWithLatest = "NA";
+
+        assertEquals(expectedVersionWithLatest, bridgeDownloadManager.extractVersionFromUrl(urlWithoutVersion));
+    }
+
+    @Test
+    public void downloadVersionFileTest() {
+        String directoryUrl = "https://sig-repo.synopsys.com/artifactory/bds-integrations-release/com/synopsys/integration/synopsys-bridge/latest";
+        String tempVersionFilePath = bridgeDownloadManager.downloadVersionFile(directoryUrl);
+        File tempVersionFile = new File(tempVersionFilePath);
+
+        assertNotNull(tempVersionFilePath);
+        assertTrue(tempVersionFile.exists());
+    }
+
+    @Test
+    void getLatestBridgeVersionFromArtifactoryTest() {
+        String urlWithVersion = "https://sig-repo.synopsys.com/artifactory/bds-integrations-release/com/synopsys/integration/synopsys-bridge/0.3.1/synopsys-bridge-0.3.1-linux64.zip ";
+        String resultWithVersion = bridgeDownloadManager.getLatestBridgeVersionFromArtifactory(urlWithVersion);
+
+        assertEquals("0.3.1", resultWithVersion);
+
+        String urlWithoutVersion = "https://sig-repo.synopsys.com/artifactory/bds-integrations-release/com/synopsys/integration/synopsys-bridge/latest/synopsys-bridge-linux64.zip";
+        String resultWithoutVersion = bridgeDownloadManager.getLatestBridgeVersionFromArtifactory(urlWithoutVersion);
+
+        assertEquals("0.3.59", resultWithoutVersion);
+
+
     }
 }

--- a/src/test/java/com/synopsys/integration/jenkins/scan/bridge/BridgeDownloadTest.java
+++ b/src/test/java/com/synopsys/integration/jenkins/scan/bridge/BridgeDownloadTest.java
@@ -15,44 +15,19 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class BridgeDownloadTest {
     private final BridgeDownload bridgeDownloadMock = Mockito.mock(BridgeDownload.class);
-    private final TaskListener listenerMock = Mockito.mock(TaskListener.class);
-    private BridgeDownload bridgeDownload;
-
-    @BeforeEach
-    public void setup() {
-        bridgeDownload = new BridgeDownload(listenerMock);
-    }
 
     @Test
     void downloadSynopsysBridgeTest() {
-        String bridgeVersion = null;
         String bridgeDownloadUrl = null;
 
         FilePath outputDownloadFilePath = new FilePath(new File(ApplicationConstants.BRIDGE_DOWNLOAD_FILE_PATH
                 .concat(ApplicationConstants.BRIDGE_ZIP_FILE_FORMAT)));
 
         Mockito.when(bridgeDownloadMock.downloadSynopsysBridge
-                ( bridgeVersion, bridgeDownloadUrl)).thenReturn(outputDownloadFilePath);
+                (bridgeDownloadUrl)).thenReturn(outputDownloadFilePath);
 
         assertEquals(outputDownloadFilePath, bridgeDownloadMock.downloadSynopsysBridge
-                (bridgeVersion, bridgeDownloadUrl));
-
-    }
-
-    @Test
-   void validateBridgeVersionTest() {
-        String bridgeVersion = "0.3.1";
-
-        assertTrue(bridgeDownload.isValidVersion(bridgeVersion));
-    }
-
-    @Test
-    void validateBridgeDownloadUrlTest() {
-        String bridgeDownloadUrl = BRIDGE_ARTIFACTORY_URL.concat(SYNOPSYS_BRIDGE_LATEST_VERSION)
-                .concat("/synopsys-bridge-").concat(PLATFORM_LINUX).concat(".zip") ;
-
-        assertTrue(bridgeDownload.isValidBridgeDownloadUrl(bridgeDownloadUrl));
-
+                (bridgeDownloadUrl));
     }
 
     @Test
@@ -64,5 +39,4 @@ public class BridgeDownloadTest {
 
         assertTrue(bridgeDownloadMock.checkIfBridgeUrlExists(bridgeUrl));
     }
-
 }

--- a/src/test/java/com/synopsys/integration/jenkins/scan/bridge/BridgeDownloadTest.java
+++ b/src/test/java/com/synopsys/integration/jenkins/scan/bridge/BridgeDownloadTest.java
@@ -3,8 +3,6 @@ import com.synopsys.integration.jenkins.scan.global.ApplicationConstants;
 
 import hudson.FilePath;
 
-import hudson.model.TaskListener;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.*;
 import java.io.File;

--- a/src/test/java/com/synopsys/integration/jenkins/scan/service/BlackDuckParametersServiceTest.java
+++ b/src/test/java/com/synopsys/integration/jenkins/scan/service/BlackDuckParametersServiceTest.java
@@ -5,22 +5,27 @@ import static org.junit.jupiter.api.Assertions.*;
 import com.synopsys.integration.jenkins.scan.global.ApplicationConstants;
 import com.synopsys.integration.jenkins.scan.input.BlackDuck;
 
+import hudson.model.TaskListener;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
 
+import java.io.PrintStream;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
 public class BlackDuckParametersServiceTest {
     private BlackDuckParametersService blackDuckParametersService;
+    private final TaskListener listenerMock = Mockito.mock(TaskListener.class);
     private final String TEST_BLACKDUCK_URL = "https://fake.blackduck.url";
     private final String TEST_BLACKDUCK_TOKEN = "MDJDSROSVC56FAKEKEY";
     private final String TEST_BLACKDUCK_INSTALL_DIRECTORY_PATH = "/path/to/blackduck/directory";
     
     @BeforeEach
     void setUp() {
-        blackDuckParametersService = new BlackDuckParametersService();
+        blackDuckParametersService = new BlackDuckParametersService(listenerMock);
+        Mockito.when(listenerMock.getLogger()).thenReturn(Mockito.mock(PrintStream.class));
     }
 
     @Test
@@ -68,7 +73,7 @@ public class BlackDuckParametersServiceTest {
 
     @Test
     void validateBlackDuckParametersForNullAndEmptyTest() {
-        BlackDuckParametersService service = new BlackDuckParametersService();
+        BlackDuckParametersService service = new BlackDuckParametersService(listenerMock);
         assertFalse(service.performBlackDuckParameterValidation(null));
 
         Map<String, Object> blackDuckParametersMap = new HashMap<>();
@@ -105,5 +110,4 @@ public class BlackDuckParametersServiceTest {
 
         assertNull(combinedMap);
     }
-
 }

--- a/src/test/java/com/synopsys/integration/jenkins/scan/service/BridgeDownloadParameterServiceTest.java
+++ b/src/test/java/com/synopsys/integration/jenkins/scan/service/BridgeDownloadParameterServiceTest.java
@@ -50,12 +50,13 @@ public class BridgeDownloadParameterServiceTest {
         String os = System.getProperty("os.name").toLowerCase();
         String userHome = System.getProperty("user.home");
 
-        String validPath = userHome;
-        String invalidPath = "/path/absent";
+        String validPath = null;
+        String invalidPath = "/path/does/not/exist";
         if (os.contains("win")) {
             validPath = String.join("\\", userHome, ApplicationConstants.DEFAULT_DIRECTORY_NAME);
             invalidPath = String.join("\\", invalidPath, ApplicationConstants.DEFAULT_DIRECTORY_NAME);
-        } else if (os.contains("nix") || os.contains("nux") || os.contains("mac")) {
+        }
+        else if (os.contains("nix") || os.contains("nux") || os.contains("mac")) {
             validPath = String.join("/", userHome, ApplicationConstants.DEFAULT_DIRECTORY_NAME);
             invalidPath = String.join("/", invalidPath, ApplicationConstants.DEFAULT_DIRECTORY_NAME);
         }
@@ -68,14 +69,23 @@ public class BridgeDownloadParameterServiceTest {
     void getBridgeDownloadParamsTest() {
         Map<String, Object> scanParams = new HashMap<>();
 
+        String bridgeDownloadUrl = "https://myown.repo.com/release/synopsys-bridge/latest/synopsys-bridge-linux64.zip";
         scanParams.put(ApplicationConstants.BRIDGE_DOWNLOAD_VERSION, "3.0.0");
-        scanParams.put(ApplicationConstants.BRIDGE_INSTALLATION_PATH, "/path/to/bridge");
+        scanParams.put(ApplicationConstants.BRIDGE_DOWNLOAD_URL, bridgeDownloadUrl );
 
         BridgeDownloadParameters result = bridgeDownloadParametersService.getBridgeDownloadParams(scanParams, bridgeDownloadParameters);
 
-        assertEquals(ApplicationConstants.BRIDGE_ARTIFACTORY_URL, result.getBridgeDownloadUrl());
-        assertEquals("3.0.0", result.getBridgeDownloadVersion());
-        assertEquals("/path/to/bridge", result.getBridgeInstallationPath());
+        assertEquals(bridgeDownloadUrl, result.getBridgeDownloadUrl());
+        assertNotEquals("3.0.0", result.getBridgeDownloadVersion());
+
+        Map<String, Object> scanParamsWithoutUrl = new HashMap<>();
+
+        scanParamsWithoutUrl.put(ApplicationConstants.BRIDGE_DOWNLOAD_VERSION, "3.0.0");
+        String bridgeDownloadUrlWithVersion = String.join("/", ApplicationConstants.BRIDGE_ARTIFACTORY_URL, "3.0.0",
+                ApplicationConstants.getSynopsysBridgeZipFileName(bridgeDownloadParametersService.getPlatform(), "3.0.0"));
+        BridgeDownloadParameters resultWithoutUrl = bridgeDownloadParametersService.getBridgeDownloadParams(scanParamsWithoutUrl, bridgeDownloadParameters);
+
+        assertEquals(bridgeDownloadUrlWithVersion, resultWithoutUrl.getBridgeDownloadUrl());
     }
 
     @Test

--- a/src/test/java/com/synopsys/integration/jenkins/scan/service/BridgeDownloadParameterServiceTest.java
+++ b/src/test/java/com/synopsys/integration/jenkins/scan/service/BridgeDownloadParameterServiceTest.java
@@ -51,14 +51,14 @@ public class BridgeDownloadParameterServiceTest {
         String userHome = System.getProperty("user.home");
 
         String validPath = null;
-        String invalidPath = "/path/does/not/exist";
+        String invalidPath = null;
         if (os.contains("win")) {
             validPath = String.join("\\", userHome, ApplicationConstants.DEFAULT_DIRECTORY_NAME);
-            invalidPath = String.join("\\", invalidPath, ApplicationConstants.DEFAULT_DIRECTORY_NAME);
+            invalidPath = String.join("\\", "\\path\\absent", ApplicationConstants.DEFAULT_DIRECTORY_NAME);
         }
         else if (os.contains("nix") || os.contains("nux") || os.contains("mac")) {
             validPath = String.join("/", userHome, ApplicationConstants.DEFAULT_DIRECTORY_NAME);
-            invalidPath = String.join("/", invalidPath, ApplicationConstants.DEFAULT_DIRECTORY_NAME);
+            invalidPath = String.join("/", "/path/absent", ApplicationConstants.DEFAULT_DIRECTORY_NAME);
         }
 
         assertTrue(bridgeDownloadParametersService.isValidInstallationPath(validPath));

--- a/src/test/java/com/synopsys/integration/jenkins/scan/service/BridgeDownloadParameterServiceTest.java
+++ b/src/test/java/com/synopsys/integration/jenkins/scan/service/BridgeDownloadParameterServiceTest.java
@@ -2,22 +2,27 @@ package com.synopsys.integration.jenkins.scan.service;
 
 import com.synopsys.integration.jenkins.scan.bridge.BridgeDownloadParameters;
 import com.synopsys.integration.jenkins.scan.global.ApplicationConstants;
+import hudson.model.TaskListener;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
 
 import static org.junit.jupiter.api.Assertions.*;
 
+import java.io.PrintStream;
 import java.util.HashMap;
 import java.util.Map;
 
 public class BridgeDownloadParameterServiceTest {
     private BridgeDownloadParametersService bridgeDownloadParametersService;
     private  BridgeDownloadParameters bridgeDownloadParameters;
+    private final TaskListener listenerMock = Mockito.mock(TaskListener.class);
 
     @BeforeEach
     void setUp() {
         bridgeDownloadParameters = new BridgeDownloadParameters();
-        bridgeDownloadParametersService = new BridgeDownloadParametersService();
+        bridgeDownloadParametersService = new BridgeDownloadParametersService(listenerMock);
+        Mockito.when(listenerMock.getLogger()).thenReturn(Mockito.mock(PrintStream.class));
     }
 
     @Test

--- a/src/test/java/com/synopsys/integration/jenkins/scan/service/ScannerArgumentServiceTest.java
+++ b/src/test/java/com/synopsys/integration/jenkins/scan/service/ScannerArgumentServiceTest.java
@@ -7,13 +7,17 @@ import com.synopsys.integration.jenkins.scan.global.BridgeParams;
 import com.synopsys.integration.jenkins.scan.input.BlackDuck;
 
 import com.synopsys.integration.jenkins.scan.input.bitbucket.Bitbucket;
+import hudson.EnvVars;
 import hudson.FilePath;
 
+import hudson.model.TaskListener;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
 
 import java.io.File;
 import java.io.IOException;
+import java.io.PrintStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -23,6 +27,9 @@ public class ScannerArgumentServiceTest {
     private BlackDuck blackDuck;
     private Bitbucket bitBucket;
     private ScannerArgumentService scannerArgumentService;
+    private final TaskListener listenerMock = Mockito.mock(TaskListener.class);
+    private final EnvVars envVarsMock = Mockito.mock(EnvVars.class);
+
 
     @BeforeEach
     void setUp() {
@@ -32,7 +39,8 @@ public class ScannerArgumentServiceTest {
 
         bitBucket = new Bitbucket();
 
-        scannerArgumentService = new ScannerArgumentService(null, null);
+        scannerArgumentService = new ScannerArgumentService(listenerMock, envVarsMock);
+        Mockito.when(listenerMock.getLogger()).thenReturn(Mockito.mock(PrintStream.class));
     }
 
     @Test


### PR DESCRIPTION
- When the user provides ` bridge_download_url` and  `bridge_download_version`, the version number is discarded, and the  **Synopsys Bridge** is downloaded from the specified URL.

- When the user provides a `bridge_download_url` with version information, such as-
 https://sig-repo.synopsys.com/artifactory/bds-integrations-release/com/synopsys/integration/synopsys-bridge/0.3.59/synopsys-bridge-0.3.59-linux64.zip
 The version is extracted from the URL itself, and the appropriate decision is made based on whether to download the bridge or perform other actions.

- When the user provides a `bridge_download_url ` without a specific version, such as-
 https://sig-repo.synopsys.com/artifactory/bds-integrations-release/com/synopsys/integration/synopsys-bridge/synopsys-bridge-linux64.zip
The plugin looks for a **versions.txt** file in the artifactory. If the file is found, it is downloaded and used to match the desired version. If the file is not found, the bridge is downloaded.
