### PR TITLE
updated blackduck_url and blackduck_api_token parameter as optional parameters

### DIFF
--- a/src/main/java/com/synopsys/integration/jenkins/scan/extension/pipeline/SecurityScanStep.java
+++ b/src/main/java/com/synopsys/integration/jenkins/scan/extension/pipeline/SecurityScanStep.java
@@ -3,14 +3,19 @@ package com.synopsys.integration.jenkins.scan.extension.pipeline;
 import com.synopsys.integration.jenkins.scan.exception.ScannerJenkinsException;
 import com.synopsys.integration.jenkins.scan.global.ApplicationConstants;
 import com.synopsys.integration.jenkins.scan.service.ScanCommandsFactory;
-
 import hudson.EnvVars;
 import hudson.Extension;
 import hudson.FilePath;
 import hudson.Launcher;
 import hudson.model.Node;
 import hudson.model.TaskListener;
-
+import java.io.IOException;
+import java.io.Serializable;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import javax.annotation.Nonnull;
 import org.jenkinsci.plugins.workflow.steps.Step;
 import org.jenkinsci.plugins.workflow.steps.StepContext;
 import org.jenkinsci.plugins.workflow.steps.StepDescriptor;
@@ -19,21 +24,12 @@ import org.jenkinsci.plugins.workflow.steps.SynchronousNonBlockingStepExecution;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.DataBoundSetter;
 
-import java.io.IOException;
-import java.io.Serializable;
-import java.util.Arrays;
-import java.util.HashSet;
-import java.util.Map;
-import java.util.Set;
-
-import javax.annotation.Nonnull;
-
 public class SecurityScanStep extends Step implements Serializable {
 
     private static final long serialVersionUID = 6294070801130995534L;
 
-    private final String blackduck_url;
-    private final String blackduck_api_token;
+    private String blackduck_url;
+    private String blackduck_api_token;
 
     private String blackduck_install_directory;
     private boolean blackduck_scan_full = true;
@@ -47,17 +43,18 @@ public class SecurityScanStep extends Step implements Serializable {
     private String synopsys_bridge_path;
 
     @DataBoundConstructor
-    public SecurityScanStep(String blackduck_url, String blackduck_api_token) {
-        this.blackduck_url = blackduck_url;
-        this.blackduck_api_token = blackduck_api_token;
-    }
-    
-    public String getBlackduck_url() {
-        return blackduck_url;
+    public SecurityScanStep() {
+        /* Intentionally left empty */
     }
 
-    public String getBlackduck_api_token() {
-        return blackduck_api_token;
+    @DataBoundSetter
+    public void setBlackduck_url(String blackduck_url) {
+        this.blackduck_url = blackduck_url;
+    }
+
+    @DataBoundSetter
+    public void setBlackduck_api_token(String blackduck_api_token) {
+        this.blackduck_api_token = blackduck_api_token;
     }
 
     @DataBoundSetter
@@ -66,7 +63,7 @@ public class SecurityScanStep extends Step implements Serializable {
     }
 
     @DataBoundSetter
-    public void setBlackduck_scan_full(Boolean blackduck_scan_full) {
+    public void setBlackduck_scan_full(boolean blackduck_scan_full) {
         this.blackduck_scan_full = blackduck_scan_full;
     }
 
@@ -76,12 +73,12 @@ public class SecurityScanStep extends Step implements Serializable {
     }
 
     @DataBoundSetter
-    public void setBlackduck_automation_fixpr(Boolean blackduck_automation_fixpr) {
+    public void setBlackduck_automation_fixpr(boolean blackduck_automation_fixpr) {
         this.blackduck_automation_fixpr = blackduck_automation_fixpr;
     }
 
     @DataBoundSetter
-    public void setBlackduck_automation_prcomment(Boolean blackduck_automation_prcomment) {
+    public void setBlackduck_automation_prcomment(boolean blackduck_automation_prcomment) {
         this.blackduck_automation_prcomment = blackduck_automation_prcomment;
     }
 
@@ -103,6 +100,14 @@ public class SecurityScanStep extends Step implements Serializable {
     @DataBoundSetter
     public void setSynopsys_bridge_path(String synopsys_bridge_path) {
         this.synopsys_bridge_path = synopsys_bridge_path;
+    }
+
+    public String getBlackduck_url() {
+        return blackduck_url;
+    }
+
+    public String getBlackduck_api_token() {
+        return blackduck_api_token;
     }
 
     public String getBlackduck_install_directory() {


### PR DESCRIPTION
- removed DataBoundConstructor for `blackduck_url` and `blackduck_api_token`
- added DataBoundSetter `blackduck_url` and `blackduck_api_token` to make it optional

**Note-** Since we are also taking these inputs from Jenkins Global Configuration, so we can make these optional in pipeline parameter.

Now we can configure the step in pipeline simply like this - `synopsys_scan()`