### PR TITLE
Gradle dependency fix.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -53,7 +53,6 @@ dependencies {
     annotationProcessor 'com.synopsys.integration:jenkins-annotation-processor:0.0.7'
 
     implementation 'org.jenkins-ci.plugins:credentials:1139.veb_9579fca_33b_'
-    implementation 'com.synopsys.integration:blackduck-common:66.1.4'
     implementation 'com.synopsys.integration:jenkins-common:0.5.5'
     implementation 'org.jvnet.localizer:localizer:1.31'
     implementation 'org.jsoup:jsoup:1.16.1'

--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ buildscript {
 }
 
 plugins {
-    id 'org.jenkins-ci.jpi' version '0.46.0'
+    id 'org.jenkins-ci.jpi' version '0.43.0'
 }
 
 group = 'com.synopsys.integration'
@@ -42,24 +42,31 @@ artifactory {
 
 jenkinsPlugin {
     pluginId = 'synopsys-security-scan-plugin'
-    jenkinsVersion = '2.387.3'
+    jenkinsVersion = '2.377'
     displayName = 'Synopsys Security Scan Plugin'
 }
 
 dependencies {
+    implementation 'org.jenkins-ci.plugins:cloudbees-bitbucket-branch-source:805.v7f97d29dc0f5'
+    implementation 'org.jenkins-ci.plugins:matrix-project:785.v06b_7f47b_c631'
+    implementation 'org.jenkins-ci.plugins:cloudbees-folder:6.15'
     annotationProcessor 'com.synopsys.integration:jenkins-annotation-processor:0.0.7'
 
+    implementation 'org.jenkins-ci.plugins:credentials:1139.veb_9579fca_33b_'
+    implementation 'com.synopsys.integration:blackduck-common:66.1.4'
     implementation 'com.synopsys.integration:jenkins-common:0.5.5'
-    implementation 'org.jenkins-ci.plugins:cloudbees-bitbucket-branch-source:809.vc1d904b_30426'
+    implementation 'org.jvnet.localizer:localizer:1.31'
     implementation 'org.jsoup:jsoup:1.16.1'
 
-    workflowJobDslApi 'org.jenkins-ci.plugins:job-dsl:1.84'
-    workflowJobApi 'org.jenkins-ci.plugins.workflow:workflow-job:1316.vd2290d3341a_f'
-    workflowCpsApi 'org.jenkins-ci.plugins.workflow:workflow-cps:3697.vb_470e454c232'
-    workflowStepApiApi 'org.jenkins-ci.plugins.workflow:workflow-step-api:625.vd896b_f445a_f8'
+    implementation 'org.jenkins-ci.plugins:plain-credentials:1.8'
 
-    testImplementation 'org.jenkins-ci.main:jenkins-test-harness:1812.v6d4e97d91fd8'
-    testImplementation 'org.junit.jupiter:junit-jupiter-engine:5.8.2'
-    testImplementation 'org.junit.jupiter:junit-jupiter-params:5.8.2'
-    testImplementation 'org.mockito:mockito-core:2.23.4'
+    workflowJobDslApi 'org.jenkins-ci.plugins:job-dsl:1.80'
+    workflowJobApi 'org.jenkins-ci.plugins.workflow:workflow-job:1203.v7b_7023424efe'
+    workflowCpsApi 'org.jenkins-ci.plugins.workflow:workflow-cps:2729.2732.vda_e3f07b_5a_f8'
+    workflowStepApiApi 'org.jenkins-ci.plugins.workflow:workflow-step-api:622.vb_8e7c15b_c95a_'
+
+    testImplementation group: 'org.jenkins-ci.main', name: 'jenkins-test-harness', version: '1812.v6d4e97d91fd8'
+    testImplementation group: 'org.junit.jupiter', name: 'junit-jupiter-engine', version: '5.6.2'
+    testImplementation group: 'org.junit.jupiter', name: 'junit-jupiter-params', version: '5.6.2'
+    testImplementation group: 'org.mockito', name: 'mockito-core', version: '2.23.4'
 }


### PR DESCRIPTION
As we discussed, we need to make synopsys-security-scan-plugin, support the jenkins version 2.377 (As the same is supported detect plugin)
Downgraded org.jenkins-ci.jpi to 0.43.0
Minimum jenkins supported version - 2.377

Added - The below versions were coming as child dependancy from bitbucket branch source plugins with older version, which were incompatible with minimum jenkins version
org.jenkins-ci.plugins:matrix-project - 785.v06b_7f47b_c631
org.jenkins-ci.plugins:cloudbees-folder - 6.15
org.jenkins-ci.plugins:credentials -1139.veb_9579fca_33b_
