### PR TITLE
modified bridge retry logic based on http status code.

### DIFF
--- a/src/main/java/com/synopsys/integration/jenkins/scan/bridge/BridgeDownload.java
+++ b/src/main/java/com/synopsys/integration/jenkins/scan/bridge/BridgeDownload.java
@@ -28,28 +28,28 @@ public class BridgeDownload {
 
                 while (!downloadSuccess && retryCount <= ApplicationConstants.BRIDGE_DOWNLOAD_MAX_RETRIES) {
                     try {
-                        listener.getLogger().printf(LogMessages.DOWNLOADING_SYNOPSYS_BRIDGE_FROM_URL, bridgeDownloadUrl);
+                        listener.getLogger().println("Downloading Synopsys Bridge from: " + bridgeDownloadUrl);
 
                         bridgeZipFilePath = workspace.child(ApplicationConstants.BRIDGE_ZIP_FILE_FORMAT);
                         bridgeZipFilePath.copyFrom(new URL(bridgeDownloadUrl));
                         downloadSuccess = true;
 
-                        listener.getLogger().printf(LogMessages.SYNOPSYS_BRIDGE_SUCCESSFULLY_DOWNLOADED_IN_PATH, bridgeZipFilePath);
+                        listener.getLogger().println("Synopsys Bridge successfully downloaded in: " + bridgeZipFilePath);
 
                     } catch (Exception e) {
                         int statusCode = getHttpStatusCode(bridgeDownloadUrl);
                         if (terminateRetry(statusCode)) {
-                            listener.getLogger().printf(LogMessages.SYNOPSYS_BRIDGE_DOWNLOAD_FAILED_WITH_STATUS, statusCode);
+                            listener.getLogger().printf("Synopsys Bridge download failed with status code: %s and plugin won't retry to download. %n", statusCode);
                             break;
                         }
-                        Thread.sleep(10000);
-                        listener.getLogger().printf(LogMessages.SYNOPSYS_BRIDGE_DOWNLOAD_FAILED_AND_RETRY, retryCount);
+                        Thread.sleep(ApplicationConstants.INTERVAL_BETWEEN_CONSECUTIVE_RETRY_ATTEMPTS);
+                        listener.getLogger().printf("Synopsys Bridge download failed and attempt#%s to download again %n", retryCount);
                         retryCount++;
                     }
                 }
 
                 if (!downloadSuccess) {
-                    listener.getLogger().printf(LogMessages.SYNOPSYS_BRIDGE_DOWNLOAD_FAILED_AND_WITH_MAX_ATTEMPT, ApplicationConstants.BRIDGE_DOWNLOAD_MAX_RETRIES);
+                    listener.getLogger().printf("Synopsys Bridge download failed after %s attempts %n", ApplicationConstants.BRIDGE_DOWNLOAD_MAX_RETRIES);
                 }
             } catch (InterruptedException e) {
                 listener.getLogger().println(LogMessages.SYNOPSYS_BRIDGE_DOWNLOAD_INTERRUPTED);

--- a/src/main/java/com/synopsys/integration/jenkins/scan/global/ApplicationConstants.java
+++ b/src/main/java/com/synopsys/integration/jenkins/scan/global/ApplicationConstants.java
@@ -28,6 +28,7 @@ public class ApplicationConstants {
     public static final String DEFAULT_DIRECTORY_NAME = "synopsys-bridge";
     public static final String BRIDGE_DIAGNOSTICS_DIRECTORY = ".bridge";
     public static final int BRIDGE_DOWNLOAD_MAX_RETRIES = 3;
+    public static final int INTERVAL_BETWEEN_CONSECUTIVE_RETRY_ATTEMPTS = 10000;
     public static final String ALL_FILES_WILDCARD_SYMBOL = "**";
     public static final String BRIDGE_BINARY = "synopsys-bridge";
     public static final String BRIDGE_BINARY_WINDOWS = "synopsys-bridge.exe";

--- a/src/main/java/com/synopsys/integration/jenkins/scan/global/LogMessages.java
+++ b/src/main/java/com/synopsys/integration/jenkins/scan/global/LogMessages.java
@@ -7,6 +7,7 @@ public class LogMessages {
 
     public static final String DOWNLOADING_SYNOPSYS_BRIDGE_FROM_URL = "Downloading Synopsys Bridge from: %s %n";
     public static final String SYNOPSYS_BRIDGE_SUCCESSFULLY_DOWNLOADED_IN_PATH = "Synopsys Bridge successfully downloaded in: %s %n";
+    public static final String SYNOPSYS_BRIDGE_DOWNLOAD_FAILED_WITH_STATUS = "Synopsys Bridge download failed with status code: %s and plugin won't retry to download. %n";
     public static final String SYNOPSYS_BRIDGE_DOWNLOAD_FAILED_AND_RETRY = "Synopsys Bridge download failed and attempt#%s to download again %n";
     public static final String SYNOPSYS_BRIDGE_DOWNLOAD_FAILED_AND_WITH_MAX_ATTEMPT = "Synopsys Bridge download failed after %s attempts %n";
     public static final String SYNOPSYS_BRIDGE_DOWNLOAD_INTERRUPTED = "Interrupted while waiting to retry Synopsys Bridge download";

--- a/src/main/java/com/synopsys/integration/jenkins/scan/global/LogMessages.java
+++ b/src/main/java/com/synopsys/integration/jenkins/scan/global/LogMessages.java
@@ -1,31 +1,15 @@
 package com.synopsys.integration.jenkins.scan.global;
 
 public class LogMessages {
-    public static final String ASTERISKS = "******************************************************************************";
-    public static final String START_BRIDGE_EXECUTION = "START EXECUTION OF SYNOPSYS BRIDGE";
-    public static final String END_BRIDGE_EXECUTION = "END EXECUTION OF SYNOPSYS BRIDGE";
-
-    public static final String DOWNLOADING_SYNOPSYS_BRIDGE_FROM_URL = "Downloading Synopsys Bridge from: %s %n";
-    public static final String SYNOPSYS_BRIDGE_SUCCESSFULLY_DOWNLOADED_IN_PATH = "Synopsys Bridge successfully downloaded in: %s %n";
-    public static final String SYNOPSYS_BRIDGE_DOWNLOAD_FAILED_WITH_STATUS = "Synopsys Bridge download failed with status code: %s and plugin won't retry to download. %n";
-    public static final String SYNOPSYS_BRIDGE_DOWNLOAD_FAILED_AND_RETRY = "Synopsys Bridge download failed and attempt#%s to download again %n";
-    public static final String SYNOPSYS_BRIDGE_DOWNLOAD_FAILED_AND_WITH_MAX_ATTEMPT = "Synopsys Bridge download failed after %s attempts %n";
     public static final String INVALID_SYNOPSYS_BRIDGE_DOWNLOAD_URL = "Invalid Synopsys Bridge download URL: %s %n";
-
     public static final String FAILED_TO_FETCH_PLUGINS_DEFAULT_INSTALLATION_PATH = "Failed to fetch plugin's default installation path: %s %n";
-
-
     public static final String BLACKDUCK_PARAMETER_VALIDATION_FAILED_FOR_PARAM = "BlackDuck parameter validation failed for %s %n";
     public static final String BLACKDUCK_PARAMETER_VALIDATION_FAILED = "BlackDuck parameters are not valid";
-
     public static final String NO_BITBUCKET_TOKEN_FOUND = "PrComment is set true but no bitbucket token found!";
-
     public static final String INVALID_BRIDGE_DOWNLOAD_PARAMETERS = "Bridge download parameters are not valid";
     public static final String EMPTY_BRIDGE_DOWNLOAD_URL_PROVIDED = "The provided Bridge download URL is empty";
     public static final String INVALID_BRIDGE_DOWNLOAD_URL_PROVIDED = "The provided Bridge download URL is not valid: %s %n";
     public static final String INVALID_BRIDGE_DOWNLOAD_VERSION_PROVIDED = "The provided Bridge download version is not valid: %s %n";
-
     public static final String EXCEPTION_OCCURRED_WHILE_INVOKING_SYNOPSYS_BRIDGE = "An exception occurred while invoking synopsys-bridge from the plugin: %s %n";
     public static final String EXCEPTION_OCCURRED_WHILE_DOWNLOADING_OR_INSTALLING_SYNOPSYS_BRIDGE = "An exception occurred while installing/downloading synopsys-bridge: %s %n";
-
 }


### PR DESCRIPTION
- For `http` code `401/403`,` 200`, `201` and `416`, the plugin won't retry to download bridge.
- The interval between consecutive retry attempts is `10 seconds.`
