### PR TITLE
Resolved Windows dev pipeline failure

### DIFF
--- a/src/test/java/com/synopsys/integration/jenkins/scan/service/ScannerArgumentServiceTest.java
+++ b/src/test/java/com/synopsys/integration/jenkins/scan/service/ScannerArgumentServiceTest.java
@@ -83,10 +83,6 @@ public class ScannerArgumentServiceTest {
         Utility.removeFile(jsonPath, workspace, listenerMock);
     }
 
-    public String getHomeDirectoryForTest() {
-        return System.getProperty("user.home");
-    }
-
     @Test
     void createCoverityInputJsonTest() {
         Coverity coverity = new Coverity();
@@ -113,7 +109,8 @@ public class ScannerArgumentServiceTest {
 
         List<String> commandLineArgs = scannerArgumentService.getCommandLineArgs(blackDuckParametersMap, scanStrategy, workspace);
 
-        assertEquals(commandLineArgs.get(0), new FilePath(new File(getHomeDirectoryForTest())).child(ApplicationConstants.DEFAULT_DIRECTORY_NAME).getRemote());
+        assertEquals(normalizePath(commandLineArgs.get(0)), normalizePath(new FilePath(new File(getHomeDirectoryForTest()))
+                .child(ApplicationConstants.DEFAULT_DIRECTORY_NAME).getRemote()));
         assertEquals(commandLineArgs.get(1), BridgeParams.STAGE_OPTION);
         assertEquals(commandLineArgs.get(2), BridgeParams.BLACKDUCK_STAGE);
         assertNotEquals(commandLineArgs.get(2), BridgeParams.COVERITY_STAGE);
@@ -137,7 +134,8 @@ public class ScannerArgumentServiceTest {
 
         List<String> commandLineArgs = scannerArgumentService.getCommandLineArgs(coverityParameters, scanStrategy, workspace);
 
-        assertEquals(commandLineArgs.get(0), new FilePath(new File(getHomeDirectoryForTest())).child(ApplicationConstants.DEFAULT_DIRECTORY_NAME).getRemote());
+        assertEquals(normalizePath(commandLineArgs.get(0)), normalizePath(new FilePath(new File(getHomeDirectoryForTest()))
+                .child(ApplicationConstants.DEFAULT_DIRECTORY_NAME).getRemote()));
         assertEquals(commandLineArgs.get(1), BridgeParams.STAGE_OPTION);
         assertEquals(commandLineArgs.get(2), BridgeParams.COVERITY_STAGE);
         assertNotEquals(commandLineArgs.get(2), BridgeParams.POLARIS_STAGE);
@@ -147,6 +145,14 @@ public class ScannerArgumentServiceTest {
         assertEquals(commandLineArgs.get(5), BridgeParams.DIAGNOSTICS_OPTION);
 
         Utility.removeFile(commandLineArgs.get(4), workspace, listenerMock);
+    }
+
+    public String getHomeDirectoryForTest() {
+        return System.getProperty("user.home");
+    }
+
+    private String normalizePath(String path) {
+        return path.replace("\\", "/");
     }
 
 }

--- a/src/test/java/com/synopsys/integration/jenkins/scan/service/ScannerArgumentServiceTest.java
+++ b/src/test/java/com/synopsys/integration/jenkins/scan/service/ScannerArgumentServiceTest.java
@@ -140,13 +140,9 @@ public class ScannerArgumentServiceTest {
         List<String> commandLineArgs = scannerArgumentService.getCommandLineArgs(coverityParameters, scanStrategy, workspace);
 
         if(getOSNameForTest().contains("win")) {
-            System.out.println("IN windows: 1 = " + commandLineArgs.get(0) + " 2: " + new FilePath(new File(getHomeDirectoryForTest()))
-                    .child(ApplicationConstants.BRIDGE_BINARY_WINDOWS).getRemote());
             assertEquals(commandLineArgs.get(0), new FilePath(new File(getHomeDirectoryForTest()))
                     .child(ApplicationConstants.BRIDGE_BINARY_WINDOWS).getRemote());
         } else {
-            System.out.println("IN LINUX: 1 = " + commandLineArgs.get(0) + " 2: " + new FilePath(new File(getHomeDirectoryForTest()))
-                    .child(ApplicationConstants.BRIDGE_BINARY_WINDOWS).getRemote());
             assertEquals(commandLineArgs.get(0), new FilePath(new File(getHomeDirectoryForTest()))
                     .child(ApplicationConstants.BRIDGE_BINARY).getRemote());
         }

--- a/src/test/java/com/synopsys/integration/jenkins/scan/service/ScannerArgumentServiceTest.java
+++ b/src/test/java/com/synopsys/integration/jenkins/scan/service/ScannerArgumentServiceTest.java
@@ -140,9 +140,13 @@ public class ScannerArgumentServiceTest {
         List<String> commandLineArgs = scannerArgumentService.getCommandLineArgs(coverityParameters, scanStrategy, workspace);
 
         if(getOSNameForTest().contains("win")) {
+            System.out.println("IN windows: 1 = " + commandLineArgs.get(0) + " 2: " + new FilePath(new File(getHomeDirectoryForTest()))
+                    .child(ApplicationConstants.BRIDGE_BINARY_WINDOWS).getRemote());
             assertEquals(commandLineArgs.get(0), new FilePath(new File(getHomeDirectoryForTest()))
                     .child(ApplicationConstants.BRIDGE_BINARY_WINDOWS).getRemote());
         } else {
+            System.out.println("IN LINUX: 1 = " + commandLineArgs.get(0) + " 2: " + new FilePath(new File(getHomeDirectoryForTest()))
+                    .child(ApplicationConstants.BRIDGE_BINARY_WINDOWS).getRemote());
             assertEquals(commandLineArgs.get(0), new FilePath(new File(getHomeDirectoryForTest()))
                     .child(ApplicationConstants.BRIDGE_BINARY).getRemote());
         }

--- a/src/test/java/com/synopsys/integration/jenkins/scan/service/ScannerArgumentServiceTest.java
+++ b/src/test/java/com/synopsys/integration/jenkins/scan/service/ScannerArgumentServiceTest.java
@@ -109,8 +109,13 @@ public class ScannerArgumentServiceTest {
 
         List<String> commandLineArgs = scannerArgumentService.getCommandLineArgs(blackDuckParametersMap, scanStrategy, workspace);
 
-        assertEquals(normalizePath(commandLineArgs.get(0)), normalizePath(new FilePath(new File(getHomeDirectoryForTest()))
-                .child(ApplicationConstants.DEFAULT_DIRECTORY_NAME).getRemote()));
+        if(getOSNameForTest().contains("win")) {
+            assertEquals(commandLineArgs.get(0), new FilePath(new File(getHomeDirectoryForTest()))
+                    .child(ApplicationConstants.BRIDGE_BINARY_WINDOWS).getRemote());
+        } else {
+            assertEquals(commandLineArgs.get(0), new FilePath(new File(getHomeDirectoryForTest()))
+                    .child(ApplicationConstants.BRIDGE_BINARY).getRemote());
+        }
         assertEquals(commandLineArgs.get(1), BridgeParams.STAGE_OPTION);
         assertEquals(commandLineArgs.get(2), BridgeParams.BLACKDUCK_STAGE);
         assertNotEquals(commandLineArgs.get(2), BridgeParams.COVERITY_STAGE);
@@ -134,8 +139,13 @@ public class ScannerArgumentServiceTest {
 
         List<String> commandLineArgs = scannerArgumentService.getCommandLineArgs(coverityParameters, scanStrategy, workspace);
 
-        assertEquals(normalizePath(commandLineArgs.get(0)), normalizePath(new FilePath(new File(getHomeDirectoryForTest()))
-                .child(ApplicationConstants.DEFAULT_DIRECTORY_NAME).getRemote()));
+        if(getOSNameForTest().contains("win")) {
+            assertEquals(commandLineArgs.get(0), new FilePath(new File(getHomeDirectoryForTest()))
+                    .child(ApplicationConstants.BRIDGE_BINARY_WINDOWS).getRemote());
+        } else {
+            assertEquals(commandLineArgs.get(0), new FilePath(new File(getHomeDirectoryForTest()))
+                    .child(ApplicationConstants.BRIDGE_BINARY).getRemote());
+        }
         assertEquals(commandLineArgs.get(1), BridgeParams.STAGE_OPTION);
         assertEquals(commandLineArgs.get(2), BridgeParams.COVERITY_STAGE);
         assertNotEquals(commandLineArgs.get(2), BridgeParams.POLARIS_STAGE);
@@ -151,8 +161,7 @@ public class ScannerArgumentServiceTest {
         return System.getProperty("user.home");
     }
 
-    private String normalizePath(String path) {
-        return path.replace("\\", "/");
+    public String getOSNameForTest() {
+        return System.getProperty("os.name");
     }
-
 }

--- a/src/test/java/com/synopsys/integration/jenkins/scan/service/ScannerArgumentServiceTest.java
+++ b/src/test/java/com/synopsys/integration/jenkins/scan/service/ScannerArgumentServiceTest.java
@@ -166,6 +166,6 @@ public class ScannerArgumentServiceTest {
     }
 
     public String getOSNameForTest() {
-        return System.getProperty("os.name");
+        return System.getProperty("os.name").toLowerCase();
     }
 }


### PR DESCRIPTION
The `windows-dev-pipeline` was failing because of the `bridge-binary` file name is different across different OS. For windows platform the bridge binary name is `synopsys-bridge.exe` while for Linux and Mac the name is `synopsys-bridge`. 

That's why Assertion was failing. 