### PR TITLE
Update bridge input json file creation path

### DIFF
--- a/src/main/java/com/synopsys/integration/jenkins/scan/service/ScannerArgumentService.java
+++ b/src/main/java/com/synopsys/integration/jenkins/scan/service/ScannerArgumentService.java
@@ -184,11 +184,16 @@ public class ScannerArgumentService {
         String inputJsonPath = null;
 
         try {
-            FilePath tempFile = workspace.createTempFile(jsonPrefix, ".json");
-            tempFile.write(inputJson, StandardCharsets.UTF_8.name());
-            inputJsonPath = tempFile.getRemote();
+            FilePath parentWorkspacePath = workspace.getParent();
+            if (parentWorkspacePath != null) {
+                FilePath tempFile = parentWorkspacePath.createTempFile(jsonPrefix, ".json");
+                tempFile.write(inputJson, StandardCharsets.UTF_8.name());
+                inputJsonPath = tempFile.getRemote();
+            } else {
+                logger.error("Failed to create json file in workspace parent path");
+            }
         } catch (Exception e) {
-            logger.error("An exception occurred while writing into input.json file: " + e.getMessage());
+            logger.error("An exception occurred while writing into json file: " + e.getMessage());
         }
 
         return inputJsonPath;

--- a/src/test/java/com/synopsys/integration/jenkins/scan/service/ScannerArgumentServiceTest.java
+++ b/src/test/java/com/synopsys/integration/jenkins/scan/service/ScannerArgumentServiceTest.java
@@ -37,7 +37,7 @@ public class ScannerArgumentServiceTest {
     @BeforeEach
     void setUp() {
         Mockito.when(listenerMock.getLogger()).thenReturn(Mockito.mock(PrintStream.class));
-        workspace = new FilePath(new File(getHomeDirectoryForTest()));
+        workspace = new FilePath(new File(getHomeDirectoryForTest())).child("mock-workspace");
 
         bitBucket = new Bitbucket();
         bitBucket.getProject().getRepository().setName("fake-repo");
@@ -106,11 +106,9 @@ public class ScannerArgumentServiceTest {
         List<String> commandLineArgs = scannerArgumentService.getCommandLineArgs(blackDuckParametersMap, workspace);
 
         if(getOSNameForTest().contains("win")) {
-            assertEquals(commandLineArgs.get(0), new FilePath(new File(getHomeDirectoryForTest()))
-                    .child(ApplicationConstants.BRIDGE_BINARY_WINDOWS).getRemote());
+            assertEquals(commandLineArgs.get(0), workspace.child(ApplicationConstants.BRIDGE_BINARY_WINDOWS).getRemote());
         } else {
-            assertEquals(commandLineArgs.get(0), new FilePath(new File(getHomeDirectoryForTest()))
-                    .child(ApplicationConstants.BRIDGE_BINARY).getRemote());
+            assertEquals(commandLineArgs.get(0), workspace.child(ApplicationConstants.BRIDGE_BINARY).getRemote());
         }
         assertEquals(commandLineArgs.get(1), BridgeParams.STAGE_OPTION);
         assertEquals(commandLineArgs.get(2), BridgeParams.BLACKDUCK_STAGE);
@@ -135,11 +133,9 @@ public class ScannerArgumentServiceTest {
         List<String> commandLineArgs = scannerArgumentService.getCommandLineArgs(coverityParameters, workspace);
 
         if(getOSNameForTest().contains("win")) {
-            assertEquals(commandLineArgs.get(0), new FilePath(new File(getHomeDirectoryForTest()))
-                    .child(ApplicationConstants.BRIDGE_BINARY_WINDOWS).getRemote());
+            assertEquals(commandLineArgs.get(0), workspace.child(ApplicationConstants.BRIDGE_BINARY_WINDOWS).getRemote());
         } else {
-            assertEquals(commandLineArgs.get(0), new FilePath(new File(getHomeDirectoryForTest()))
-                    .child(ApplicationConstants.BRIDGE_BINARY).getRemote());
+            assertEquals(commandLineArgs.get(0), workspace.child(ApplicationConstants.BRIDGE_BINARY).getRemote());
         }
         assertEquals(commandLineArgs.get(1), BridgeParams.STAGE_OPTION);
         assertEquals(commandLineArgs.get(2), BridgeParams.COVERITY_STAGE);


### PR DESCRIPTION
Since json file was previously being created in source code path so the json file was also being scanned by tools.
Now it is being created in workspace parent path therefore it's out of scope for scanning.