### PR TITLE
Add deploying logic to pom.xml

### DIFF
--- a/.github/workflows/jenkins-security-scan.yml
+++ b/.github/workflows/jenkins-security-scan.yml
@@ -19,5 +19,5 @@ jobs:
   security-scan:
     uses: jenkins-infra/jenkins-security-scan/.github/workflows/jenkins-security-scan.yaml@v2
     with:
-      java-cache: 'gradle' # Optionally enable use of a build dependency cache. Specify 'maven' or 'gradle' as appropriate.
+      java-cache: 'maven' # Optionally enable use of a build dependency cache. Specify 'maven' or 'gradle' as appropriate.
       java-version: 11 # What version of Java to set up for the build.

--- a/pom.xml
+++ b/pom.xml
@@ -118,7 +118,7 @@
       <distributionManagement>
         <snapshotRepository>
           <id>bds-artifactory</id>
-          <url>https://artifactory.internal.synopsys.com/artifactory/bds-integrations-snapshot</url>
+          <url>${snapshotArtifactoryUrl}</url>
         </snapshotRepository>
       </distributionManagement>
     </profile>
@@ -130,7 +130,7 @@
       <distributionManagement>
         <repository>
           <id>bds-artifactory</id>
-          <url>https://artifactory.internal.synopsys.com/artifactory/bds-integrations-release</url>
+          <url>${releaseArtifactoryUrl}</url>
         </repository>
       </distributionManagement>
     </profile>
@@ -142,11 +142,11 @@
       <distributionManagement>
         <repository>
           <id>bds-artifactory</id>
-          <url>https://artifactory.internal.synopsys.com/artifactory/bds-integrations-test</url>
+          <url>${qaArtifactoryUrl}</url>
         </repository>
         <snapshotRepository>
           <id>bds-artifactory</id>
-          <url>https://artifactory.internal.synopsys.com/artifactory/bds-integrations-snapshot</url>
+          <url>${snapshotArtifactoryUrl}</url>
         </snapshotRepository>
       </distributionManagement>
     </profile>
@@ -159,7 +159,7 @@
     </repository>
     <repository>
       <id>bds-artifactory</id>
-      <url>https://sig-repo.synopsys.com/bds-integrations-release</url>
+      <url>${repoReleaseArtifactoryUrl}</url>
     </repository>
   </repositories>
   <pluginRepositories>

--- a/pom.xml
+++ b/pom.xml
@@ -109,10 +109,57 @@
     </dependency>
   </dependencies>
 
+  <profiles>
+    <profile>
+      <id>snapshot-deployment</id>
+      <activation>
+        <activeByDefault>false</activeByDefault>
+      </activation>
+      <distributionManagement>
+        <snapshotRepository>
+          <id>bds-artifactory</id>
+          <url>https://artifactory.internal.synopsys.com/artifactory/bds-integrations-snapshot</url>
+        </snapshotRepository>
+      </distributionManagement>
+    </profile>
+    <profile>
+      <id>deployment</id>
+      <activation>
+        <activeByDefault>false</activeByDefault>
+      </activation>
+      <distributionManagement>
+        <repository>
+          <id>bds-artifactory</id>
+          <url>https://artifactory.internal.synopsys.com/artifactory/bds-integrations-release</url>
+        </repository>
+      </distributionManagement>
+    </profile>
+    <profile>
+      <id>qa-deployment</id>
+      <activation>
+        <activeByDefault>false</activeByDefault>
+      </activation>
+      <distributionManagement>
+        <repository>
+          <id>bds-artifactory</id>
+          <url>https://artifactory.internal.synopsys.com/artifactory/bds-integrations-test</url>
+        </repository>
+        <snapshotRepository>
+          <id>bds-artifactory</id>
+          <url>https://artifactory.internal.synopsys.com/artifactory/bds-integrations-snapshot</url>
+        </snapshotRepository>
+      </distributionManagement>
+    </profile>
+  </profiles>
+
   <repositories>
     <repository>
       <id>repo.jenkins-ci.org</id>
       <url>https://repo.jenkins-ci.org/public/</url>
+    </repository>
+    <repository>
+      <id>bds-artifactory</id>
+      <url>https://sig-repo.synopsys.com/bds-integrations-release</url>
     </repository>
   </repositories>
   <pluginRepositories>


### PR DESCRIPTION
This is the deployment logic which needs to be added to pom.xml in order to get the snapshots and for release activities.